### PR TITLE
Add Qiita link button

### DIFF
--- a/SandboxForAIWithiOS/ContentView.swift
+++ b/SandboxForAIWithiOS/ContentView.swift
@@ -8,12 +8,21 @@
 import SwiftUI
 
 struct ContentView: View {
+    @Environment(\.openURL) private var openURL
+
     var body: some View {
         VStack {
             Image(systemName: "globe")
                 .imageScale(.large)
                 .foregroundStyle(.tint)
             Text("Hello, world!")
+
+            Button("Open Qiita") {
+                if let url = URL(string: "https://qiita.com/") {
+                    openURL(url)
+                }
+            }
+            .padding(.top)
         }
         .padding()
     }


### PR DESCRIPTION
## Summary
- add a button to open `https://qiita.com/` in the default browser

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_686a7bd1210883219788fdc936fd6f32